### PR TITLE
Feat/#28 로그아웃 버튼 구현

### DIFF
--- a/src/components/sign/SignOut.css
+++ b/src/components/sign/SignOut.css
@@ -1,0 +1,13 @@
+.sign-out {
+  border: 2px solid #82dcff;
+  border-radius: 24px;
+  background-color: #fff;
+  color: #7a7a7a;
+  font-size: 16px;
+  padding: 8px;
+  position: fixed;
+  right: 10px;
+  bottom: 10px;
+  cursor: pointer;
+  font-weight: bold;
+}

--- a/src/components/sign/SignOut.tsx
+++ b/src/components/sign/SignOut.tsx
@@ -1,8 +1,15 @@
 import React from 'react';
 import './SignOut.css';
+import { useNavigate } from 'react-router-dom';
 
 const SignOut: React.FC = () => {
-  return <div className='sign-out'>로그아웃</div>;
+  const navigator = useNavigate();
+
+  return (
+    <div onClick={() => navigator('/login')} className='sign-out'>
+      로그아웃
+    </div>
+  );
 };
 
 export default SignOut;

--- a/src/components/sign/SignOut.tsx
+++ b/src/components/sign/SignOut.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import './SignOut.css';
+
+const SignOut: React.FC = () => {
+  return <div className='sign-out'>로그아웃</div>;
+};
+
+export default SignOut;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -2,10 +2,12 @@ import React from 'react';
 import './HomePage.css';
 import ContentPage from './ContentPage';
 import Sidebar from '../components/sidebar/Sidebar';
+import SignOut from '../components/sign/SignOut';
 
 const HomePage: React.FC = () => {
   return (
     <>
+      <SignOut />
       <Sidebar />
       <ContentPage />
     </>


### PR DESCRIPTION
<!-- PR 제목 설정 ➡️ [type/#이슈번호] 작업내용 -->


## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#28 

## 📄 Work Description
<!-- 커밋 ID 앞 6자리와 해당 커밋에서의 작업 내용을 간략히 설명해주세요 -->
홈페이지에서 로그아웃 버튼이 우측하단에 위치하도록 구현했습니다.
클릭시 로그인 페이지로 전환되는 기능만 추가했습니다. 

## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->
![image](https://github.com/user-attachments/assets/7a2a4035-57fe-4a39-aa7a-4cebefe2500a)


## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->
